### PR TITLE
Makes building on x86_64 Linux work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LD        = $(CROSS_COMPILE)ld
 OBJDUMP   = $(CROSS_COMPILE)objdump
 OBJCOPY   = $(CROSS_COMPILE)objcopy
 CFLAGS    = -m32
-LDFLAGS   = -nostartfile
+LDFLAGS   = -mi386pe
 
 # For the flashrom bootblock layout
 ifeq ($(BB_SIZE), 4K)


### PR DESCRIPTION
Hello Pete Batard,

There was some trouble with the LDFLAGS youve set for both the ubrx and the vmbios-1.0 example on your blog: https://pete.akeo.ie/2011/06/crafting-bios-from-scratch.html
These settings might work well with mingw32, but they were not compatible with GNU GCC.

first I had to comment out the CROSS_COMPILE variable, which is obvious.
But then I got:
```sh
$ make
[AS]  bios.S
[LD]  bios.out
ld: Error: unable to disambiguate: -nostartfile (did you mean --nostartfile ?)
make: *** [Makefile:41: bios.out] Error 1
```
Took me a bit to understand what where (I understand your building i386 code that dont need like linux or windows executable start code and stuff)

So I tried without the nostartfile flag (tried the double dash --, and --nostartflags, googled a ton, maybe not enough?)
```sh
$ make
[AS]  bios.S
[LD]  bios.out
[ROM] bios.rom
objcopy: warning: bios.out: corrupt GNU_PROPERTY_TYPE (5) type (0x4) datasz: 0x1
```
Which made me think, your altering something or objcopy is confused but your properly making your files. whats wrong? do i need to tell LD or objcopy something?
looking at the LD man page, i spotted the m flag, and a few intresting "emulations" one of which being i386pe (tried pep, worked too, but showed weird errors upon building)

thus, changing the LFFLAGS to be ``LDFLAGS   = -mi386pe`` worked. 
I did not test this on windows with Mingw, nor on a x86 (32bit) machine, which I could try. the "LDEMULATION" environment variable might also be of intrest but I got both vmbios and ubrx compiled using this change, and am happy.  

I hope this pullrequest is clear enough and simple enough to test. if you dont see time to test your own favorite compile hosts, I atleast am willing to also test this on a older 32bit machine, windows might be tricky for me. Hope all is well and appreciate my attempt in helping someone who might try this "older" project aswell.

Have a wonderful day,
Nico (CodeAsm)